### PR TITLE
Fix PHP 8.1 deprecation warnings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -331,7 +331,7 @@ function print_alumni($infos) {
 // em um array associativo de chave($_key)
 function transf_assoc_array($labels, $fd, $_key) {
     $ret_array = [];
-    while (($data = fgetcsv($fd, 10000, "\t")) != FALSE) {
+    while (($data = fgetcsv($fd, 10000, "\t", '"', "\\")) != FALSE) {
         $temp = [];
         for ($i=0; $i < count($data); $i++) { 
             $temp[$labels[$i]]=$data[$i];

--- a/listagem/layout_dinamico_team.php
+++ b/listagem/layout_dinamico_team.php
@@ -27,7 +27,7 @@ get_header();
     <?php
         // Professores
         $open = fopen(get_field('professors_file'), "r");
-        $campos = fgetcsv($open, 10000, "\t");
+        $campos = fgetcsv($open, 10000, "\t", '"', "\\");
         $professors = transf_assoc_array($campos, $open, 'Nome');
         // print_r($professors);
     ?>
@@ -45,7 +45,7 @@ get_header();
     <?php 
         // Collaborators
         $open = fopen(get_field('collaborators_researchers_file'), "r");
-        $campos = fgetcsv($open, 10000, "\t");
+        $campos = fgetcsv($open, 10000, "\t", '"', "\\");
         $collab_res = transf_assoc_array($campos, $open, 'Nome');
         // print_r($collab_res);
     ?>
@@ -78,7 +78,7 @@ get_header();
     <?php
         // PHD
         $open = fopen(get_field('students_file'), "r");
-        $campos = fgetcsv($open, 10000, "\t");
+        $campos = fgetcsv($open, 10000, "\t", '"', "\\");
         $data = transf_assoc_array($campos, $open, 'Full Name');
         ksort($data);
     ?>

--- a/listagem/modelo_alumni_dinamico.php
+++ b/listagem/modelo_alumni_dinamico.php
@@ -2,7 +2,7 @@
 get_header();
 
 $open = fopen(get_field('alumni_file'), "r");
-$campos = fgetcsv($open, 10000, "\t");
+$campos = fgetcsv($open, 10000, "\t", '"', "\\");
 $data = transf_assoc_array($campos, $open, 'Aluno');
 // print_r($data);
 


### PR DESCRIPTION
## Summary
- specify the escape parameter for all `fgetcsv` calls

## Testing
- `php -l functions.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d5cbb02008321a1d59d92d2fa32f7