### PR TITLE
Fix typo in CSS comment

### DIFF
--- a/personalizado/personalizado.css
+++ b/personalizado/personalizado.css
@@ -317,7 +317,7 @@ h3.section_title {
     }
 }
 
-/* professoress */
+/* professores */
 .cards_container.professors {
     grid-template-columns: 1fr 1fr;
     align-items: center;


### PR DESCRIPTION
## Summary
- fix typo in comment referencing professors in `personalizado.css`

## Testing
- `grep -n "professores" personalizado/personalizado.css`

------
https://chatgpt.com/codex/tasks/task_e_685d5e228424832182c9c9195da5a9ff