### PR TITLE
Fix alumni markup

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -298,7 +298,7 @@ function print_alumni($infos) {
                 echo "
                         </div>
                         <div class='card_academic'>
-                            <p>Defended his <bold>".$infos['Tipo']."</bold> in <bold>".$infos['Ano de defesa']."</bold></p>
+                            <p>Defended his <strong>".$infos['Tipo']."</strong> in <strong>".$infos['Ano de defesa']."</strong></p>
                             <p>Guided by <a href='/team/#professors'>".$infos['Orientador']."</a></p>
                         </div>
                         </div>


### PR DESCRIPTION
## Summary
- replace `<bold>` tags with `<strong>` in alumni description

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5e2e9d948321a51de07871b5c842